### PR TITLE
Add a pulse-simple backend

### DIFF
--- a/source/olc_swe_template.h
+++ b/source/olc_swe_template.h
@@ -177,6 +177,8 @@ namespace olc::sound
 
 ///[OLC_HM] INSERT swe_system_alsa.h ALSA_H
 
+///[OLC_HM] INSERT swe_system_pulse.h PULSE_H
+
 #ifdef OLC_SOUNDWAVE
 #undef OLC_SOUNDWAVE
 
@@ -202,6 +204,7 @@ namespace olc::sound
 ///[OLC_HM] INSERT swe_system_winmm.cpp WINMM_CPP
 ///[OLC_HM] INSERT swe_system_sdlmixer.cpp SDLMIXER_CPP
 ///[OLC_HM] INSERT swe_system_alsa.cpp ALSA_CPP
+///[OLC_HM] INSERT swe_system_pulse.cpp PULSE_CPP
 
 #endif // OLC_SOUNDWAVE IMPLEMENTATION
 #endif // OLC_SOUNDWAVE_H

--- a/source/swe_prefix.h
+++ b/source/swe_prefix.h
@@ -28,7 +28,7 @@
 		#define SOUNDWAVE_USING_WINMM
 	#endif
 	#if defined(__linux__)
-		#define SOUNDWAVE_USING_ALSA
+		#define SOUNDWAVE_USING_PULSE
 	#endif
 	#if defined(__APPLE__)
 		#define SOUNDWAVE_USING_SDLMIXER

--- a/source/swe_prefix.h
+++ b/source/swe_prefix.h
@@ -21,7 +21,8 @@
 // Compiler/System Sensitivity
 #if !defined(SOUNDWAVE_USING_WINMM) && !defined(SOUNDWAVE_USING_WASAPI) &&  \
     !defined(SOUNDWAVE_USING_XAUDIO) && !defined(SOUNDWAVE_USING_OPENAL) && \
-    !defined(SOUNDWAVE_USING_ALSA) && !defined(SOUNDWAVE_USING_SDLMIXER)    \
+    !defined(SOUNDWAVE_USING_ALSA) && !defined(SOUNDWAVE_USING_SDLMIXER) && \
+    !defined(SOUNDWAVE_USING_PULSE)                                         \
 
 	#if defined(_WIN32)
 		#define SOUNDWAVE_USING_WINMM

--- a/source/swe_system_pulse.cpp
+++ b/source/swe_system_pulse.cpp
@@ -1,0 +1,88 @@
+#include "swe_system_pulse.h"
+
+#include "swe_wave_engine.h"
+
+
+///[OLC_HM] START PULSE_CPP
+#if defined(SOUNDWAVE_USING_PULSE)
+// PULSE Driver Implementation
+#include <pulse/error.h>
+#include <iostream>
+
+namespace olc::sound::driver
+{
+	PulseAudio::PulseAudio(WaveEngine* pHost) : Base(pHost)
+	{ }
+
+	PulseAudio::~PulseAudio()
+	{
+		Stop();
+		Close();
+	}
+
+	bool PulseAudio::Open(const std::string& sOutputDevice, const std::string& sInputDevice)
+	{
+		pa_sample_spec ss {
+			PA_SAMPLE_FLOAT32, m_pHost->GetSampleRate(), (uint8_t)m_pHost->GetChannels()
+		};
+
+		m_pPA = pa_simple_new(NULL, "olcSoundWaveEngine", PA_STREAM_PLAYBACK, NULL,
+		                      "Output Stream", &ss, NULL, NULL, NULL);
+
+		if (m_pPA == NULL)
+			return false;
+
+		return true;
+	}
+
+	bool PulseAudio::Start()
+	{
+		m_bDriverLoopActive = true;
+		m_thDriverLoop = std::thread(&PulseAudio::DriverLoop, this);
+
+		return true;
+	}
+
+	void PulseAudio::Stop()
+	{
+		// Signal the driver loop to exit
+		m_bDriverLoopActive = false;
+
+		// Wait for driver thread to exit gracefully
+		if (m_thDriverLoop.joinable())
+			m_thDriverLoop.join();
+	}
+
+	void PulseAudio::Close()
+	{
+		if (m_pPA != nullptr)
+		{
+			pa_simple_free(m_pPA);
+			m_pPA = nullptr;
+		}
+	}
+
+	void PulseAudio::DriverLoop()
+	{
+		// We will be using this vector to transfer to the host for filling, with
+		// user sound data (float32, -1.0 --> +1.0)
+		std::vector<float> vFloatBuffer(m_pHost->GetBlockSampleCount(), 0.0f);
+
+		// While the system is active, start requesting audio data
+		while (m_bDriverLoopActive)
+		{
+			// Grab audio data from user
+			GetFullOutputBlock(vFloatBuffer);
+
+			// Fill PulseAudio data buffer
+			int error;
+			if (pa_simple_write(m_pPA, vFloatBuffer.data(),
+			                    vFloatBuffer.size() * sizeof(float), &error) < 0)
+			{
+				std::cerr << "Failed to feed data to PulseAudio: " << pa_strerror(error) << "\n";
+			}
+		}
+	}
+} // PulseAudio Driver Implementation
+#endif
+///[OLC_HM] END PULSE_CPP

--- a/source/swe_system_pulse.h
+++ b/source/swe_system_pulse.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "swe_system_base.h"
+
+///[OLC_HM] START PULSE_H
+#if defined(SOUNDWAVE_USING_PULSE)
+#include <pulse/simple.h>
+
+namespace olc::sound::driver
+{
+	class PulseAudio : public Base
+	{
+	public:
+		PulseAudio(WaveEngine* pHost);
+		~PulseAudio();
+
+	protected:
+		bool Open(const std::string& sOutputDevice, const std::string& sInputDevice) 	override;
+		bool Start() 	override;
+		void Stop()		override;
+		void Close()	override;
+
+	private:
+		void DriverLoop();
+
+		pa_simple *m_pPA;
+		std::atomic<bool> m_bDriverLoopActive{ false };
+		std::thread m_thDriverLoop;
+	};
+}
+#endif // SOUNDWAVE_USING_PULSE
+///[OLC_HM] END PULSE_H

--- a/source/swe_wave_engine.cpp
+++ b/source/swe_wave_engine.cpp
@@ -31,6 +31,10 @@ namespace olc::sound
 #if defined(SOUNDWAVE_USING_SDLMIXER)
 		m_driver = std::make_unique<driver::SDLMixer>(this);
 #endif
+
+#if defined(SOUNDWAVE_USING_PULSE)
+		m_driver = std::make_unique<driver::PulseAudio>(this);
+#endif
 	}
 
 	WaveEngine::~WaveEngine()


### PR DESCRIPTION
PulseAudio seems like a better "default" sound system on Linux, especially since so many people are having issues with ALSA.

At least for now we're going to rely on the "simple" version of the API, which is synchronous but probably still good enough for most use cases.