### PR TITLE
fix nagging in emscripten

### DIFF
--- a/source/swe_synth_osc.cpp
+++ b/source/swe_synth_osc.cpp
@@ -24,15 +24,15 @@ namespace olc::sound::synth
 				break;
 
 			case Type::Square:
-				output = amplitude.value * (phase_acc >= 1.0) ? 1.0 : -1.0;
+				output = amplitude.value * ((phase_acc >= 1.0) ? 1.0 : -1.0);
 				break;
 
 			case Type::Triangle:
-				output = amplitude.value * (phase_acc < 1.0) ? (phase_acc * 0.5) : (1.0 - phase_acc * 0.5);
+				output = amplitude.value * ((phase_acc < 1.0) ? (phase_acc * 0.5) : (1.0 - phase_acc * 0.5));
 				break;
 
 			case Type::PWM:
-				output = amplitude.value * (phase_acc >= (parameter.value + 1.0)) ? 1.0 : -1.0;
+				output = amplitude.value * ((phase_acc >= (parameter.value + 1.0)) ? 1.0 : -1.0);
 				break;
 
 			case Type::Wave:


### PR DESCRIPTION
```bash
In file included from /home/jon/Projects/olcSoundWaveEngine/demos/Test_004_PGE_RawDataPlayback.cpp:2:
/home/jon/Projects/olcSoundWaveEngine/demos/olcPixelGameEngine.h:4123:13: warning: enumeration value 'MODEL3D' not handled in switch [-Wswitch]
                                switch (mode)
                                        ^~~~
In file included from /home/jon/Projects/olcSoundWaveEngine/demos/Test_004_PGE_RawDataPlayback.cpp:5:
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1352:51: warning: operator '?:' has lower precedence than '*'; '*' will be evaluated first [-Wparentheses]
                                output = amplitude.value * (phase_acc >= 1.0) ? 1.0 : -1.0;
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1352:51: note: place parentheses around the '*' expression to silence this warning
                                output = amplitude.value * (phase_acc >= 1.0) ? 1.0 : -1.0;
                                                                              ^
                                         (                                   )
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1352:51: note: place parentheses around the '?:' expression to evaluate it first
                                output = amplitude.value * (phase_acc >= 1.0) ? 1.0 : -1.0;
                                                                              ^
                                                           (                              )
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1356:50: warning: operator '?:' has lower precedence than '*'; '*' will be evaluated first [-Wparentheses]
                                output = amplitude.value * (phase_acc < 1.0) ? (phase_acc * 0.5) : (1.0 - phase_acc * 0.5);
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1356:50: note: place parentheses around the '*' expression to silence this warning
                                output = amplitude.value * (phase_acc < 1.0) ? (phase_acc * 0.5) : (1.0 - phase_acc * 0.5);
                                                                             ^
                                         (                                  )
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1356:50: note: place parentheses around the '?:' expression to evaluate it first
                                output = amplitude.value * (phase_acc < 1.0) ? (phase_acc * 0.5) : (1.0 - phase_acc * 0.5);
                                                                             ^
                                                           (                                                              )
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1360:71: warning: operator '?:' has lower precedence than '*'; '*' will be evaluated first [-Wparentheses]
                                output = amplitude.value * (phase_acc >= (parameter.value + 1.0)) ? 1.0 : -1.0;
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1360:71: note: place parentheses around the '*' expression to silence this warning
                                output = amplitude.value * (phase_acc >= (parameter.value + 1.0)) ? 1.0 : -1.0;
                                                                                                  ^
                                         (                                                       )
/home/jon/Projects/olcSoundWaveEngine/demos/../olcSoundWaveEngine.h:1360:71: note: place parentheses around the '?:' expression to evaluate it first
                                output = amplitude.value * (phase_acc >= (parameter.value + 1.0)) ? 1.0 : -1.0;
                                                                                                  ^
                                                           (                                                  )
```
