### PR TITLE
Fixed #35 Properly handle 8-bit PCM

### DIFF
--- a/source/swe_wave_file.h
+++ b/source/swe_wave_file.h
@@ -130,6 +130,7 @@ namespace olc::sound::wave
 					{
 						int8_t s = 0;
 						ifs.read((char*)&s, sizeof(int8_t));
+						s = s - 128; //Correct value since 8-bit PCM is unsigned.
 						*pSample = T(s) / T(std::numeric_limits<int8_t>::max());
 					}
 					break;


### PR DESCRIPTION
Unfornately I can't figure out how to re-generate the single header file. But this fixes  8-bit PCM support. 

Tested it by putting the single line edit into the header file manually for the build of my olcCodeJam 2023 entry.